### PR TITLE
Add low-level test for us ticker.

### DIFF
--- a/low_level_tests/lib/BMComm.h
+++ b/low_level_tests/lib/BMComm.h
@@ -1,0 +1,108 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "drivers/RawSerial.h"
+#include "platform/NonCopyable.h"
+
+#define BUFFER_SIZE_SYNC 30
+
+/* Class to handle communication with the host part of the test. */
+class BMComm: private mbed::NonCopyable<BMComm>
+{
+
+public:
+
+    BMComm(PinName tx, PinName rx, int baud = 9600)
+    {
+        _serial = new mbed::RawSerial(tx, rx, baud);
+    }
+
+    ~BMComm()
+    {
+        delete _serial;
+    }
+
+    /* Function writes provided null string to the serial port. */
+    void write_line(const char *str)
+    {
+        while (true) {
+            _serial->putc(*str);
+            if (*str == '\0') {
+                break;
+            }
+
+            str++;
+        };
+    }
+
+    /* Function reads null terminated string from the serial port. */
+    int read_line(char *buffer)
+    {
+        int count = 0;
+        while (true) {
+            *buffer = (char) _serial->getc();
+            count++;
+            if (*buffer == '\0') {
+                return count;
+            }
+
+            buffer += 1;
+        }
+    }
+
+    /* Function perform synchronisation between both parts of the test (host and device). */
+    void sync_host_dev()
+    {
+        char buffer[BUFFER_SIZE_SYNC];
+
+        read_line(buffer);
+
+        while (strCmp(buffer, (char*) "__sync") != 0) {
+            wait_cycles(1000);
+            read_line(buffer);
+        }
+
+        /* If we are here, then sync signal has been received from host.
+         * Indicate that the device is ready for test.
+         */
+        write_line("__ready");
+    }
+
+private:
+
+    /* Function which provides delay. */
+    void wait_cycles(int volatile cycles)
+    {
+        while (cycles--)
+            ;
+    }
+
+    /* Function compares provided strings and returns 0 if are equal. */
+    int strCmp(const char string1[], char string2[])
+    {
+        for (int i = 0;; i++) {
+            if (string1[i] != string2[i]) {
+                return string1[i] < string2[i] ? -1 : 1;
+            }
+
+            if (string1[i] == '\0') {
+                return 0;
+            }
+        }
+    }
+
+    mbed::RawSerial * _serial;
+};
+

--- a/low_level_tests/lib/BMTest.h
+++ b/low_level_tests/lib/BMTest.h
@@ -1,0 +1,177 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "BMComm.h"
+
+typedef enum
+{
+    PASSED, FAILED
+} test_case_status_t;
+
+typedef enum
+{
+    SYNC_OK, SYNC_ERR
+} sync_status_t;
+
+#define BUFFER_SIZE 100
+
+#define BM_TEST_ASSERT(TEST_OBJ, CONDITION) TEST_OBJ.assert_cond(CONDITION, __LINE__)
+
+/* Test class to support bare metal tests.
+ *
+ * Example usage:
+ *
+ *  BMTest test;
+ *
+ *  test.set_transmission_params(USBTX, USBRX, BAUD_RATE);
+ *  test.sync_host_dev();
+ *  test.set_timeout(10);
+ *  test.exec_test_case(test_func_1, "Verify that...", NULL);
+ *  test.exec_test_case(test_func_2, "Verify that...", "<host support function>");
+ *  test.done();
+ *
+ *
+ * Note:
+ *  <host support function> is used to define function which should be executed
+ *  on the host side for this test case.
+ *
+ */
+class BMTest
+{
+
+public:
+    typedef void (*Test_function_t)(BMTest& test);
+
+    BMTest()
+    {
+        _comm = NULL;
+        _sync_complete = SYNC_ERR;
+        _test_status = PASSED;
+        _tc_total_cnt = 0;
+        _tc_pass_cnt = 0;
+        _tc_fail_cnt = 0;
+    }
+
+    ~BMTest()
+    {
+        delete _comm;
+    }
+
+    /* Send string to the host. */
+    void send(char * buffer)
+    {
+        if (_comm != NULL) {
+            _comm->write_line(buffer);
+        }
+    }
+
+    /* Receive string from the host. */
+    int receive(char * buffer)
+    {
+        if (_comm != NULL) {
+            return _comm->read_line(buffer);
+        }
+
+        return 0;
+    }
+
+    /* Set UART pins used for transmission and select transmission speed. */
+    void set_transmission_params(PinName tx, PinName rx, int baud)
+    {
+        _comm = new BMComm(tx, rx, baud);
+    }
+
+    /* Sync communication between device and host. */
+    void sync_host_dev()
+    {
+        if (_comm != NULL) {
+            _comm->sync_host_dev();
+
+            /* If we are here, then sync was successful. */
+            _sync_complete = SYNC_OK;
+        }
+    }
+
+    /* Set test timeout. */
+    void set_timeout(unsigned int seconds)
+    {
+        snprintf(_buffer, sizeof(_buffer), "{\"cmd\": \"timeout\", \"val\": \"%u\"}", seconds);
+        send(_buffer);
+    }
+
+    /* Execute single test case. */
+    void exec_test_case(Test_function_t test_case, const char * description, const char * host_test_func)
+    {
+        _tc_status = PASSED;
+        _tc_total_cnt++;
+
+        if (_sync_complete == SYNC_OK) {
+            snprintf(_buffer, sizeof(_buffer), "{\"cmd\": \"description\", \"val\": \"%s\"}", description);
+            send(_buffer);
+
+            if (host_test_func) {
+                snprintf(_buffer, sizeof(_buffer), "{\"cmd\": \"host_test\", \"val\": \"%s\"}", host_test_func);
+            } else {
+                snprintf(_buffer, sizeof(_buffer), "{\"cmd\": \"host_test\", \"val\": \"%s\"}", "(null)");
+            }
+
+            send(_buffer);
+
+            test_case(*this);
+
+            if (_tc_status == PASSED) {
+                snprintf(_buffer, sizeof(_buffer), "{\"cmd\": \"status\", \"val\": \"%s\"}", "PASSED");
+                _tc_pass_cnt++;
+            } else {
+                snprintf(_buffer, sizeof(_buffer), "{\"cmd\": \"status\", \"val\": \"%s\"}", "FAILED");
+                _tc_fail_cnt++;
+            }
+
+            send(_buffer);
+        }
+    }
+
+    /* Test case assertion to verify result. */
+    void assert_cond(bool condition, int line)
+    {
+        if (!condition) {
+            snprintf(_buffer, sizeof(_buffer), "{\"cmd\": \"assert\", \"val\": \"%d%s\"}", line,
+                    "::FAIL: Expression Evaluated To FALSE");
+            send(_buffer);
+            _tc_status = FAILED;
+            _test_status = FAILED;
+        }
+    }
+
+    /* Indicate that test is finished. */
+    void done()
+    {
+        snprintf(_buffer, sizeof(_buffer),
+                "{\"cmd\": \"done\", \"val\": {\"total\": \"%d\", \"passed\": \"%d\",\"failed\": \"%d\"}}",
+                _tc_total_cnt, _tc_pass_cnt, _tc_fail_cnt);
+        send(_buffer);
+    }
+
+private:
+    BMComm * _comm;
+    sync_status_t _sync_complete;
+    test_case_status_t _tc_status;
+    test_case_status_t _test_status;
+    unsigned int _tc_total_cnt;
+    unsigned int _tc_pass_cnt;
+    unsigned int _tc_fail_cnt;
+    char _buffer[BUFFER_SIZE];
+};
+

--- a/low_level_tests/us_ticker/main.cpp
+++ b/low_level_tests/us_ticker/main.cpp
@@ -1,0 +1,255 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* UART TEST FOR GREEN TEA
+ *
+ *  For basic functionality of the Grean-Tea and utest frameworks us ticker is not
+ *  required. Advanced usage (using of asynchronous test cases) requires
+ *  running us ticker since utest framework uses Timeout class to execute callback
+ *  after the specified time.
+ *
+ *
+ * utest framework uses Timeout class to execute callbacks after the specified
+ * time.
+ * Timeout class must provide valid implementation of the following
+ * methods (used by utest framework):
+ *  - void attach_us(Callback<void()> func, us_timestamp_t t);
+ *  - void detach();
+ *  For this purpose us ticker target specific drivers must provide
+ *  us ticker counter which counts ticks with the specified frequency
+ *  and is able to schedule interrupt at the specified point in time.
+ *
+ * TEST SCENARIO
+ * This part of the test is executed on mbed board and communicates with host.
+ *
+ */
+#include "../lib/BMTest.h"
+#include "mbed.h"
+#include "hal/us_ticker_api.h"
+
+using namespace mbed;
+
+static volatile unsigned int int_cnt;
+
+#define BAUD_RATE 9600
+#define TICKS_DELTA 10
+
+void wait_cycles(int volatile cycles)
+{
+    while (cycles--)
+        ;
+}
+
+void us_ticker_isr(const ticker_data_t * const ticker)
+{
+    (void) ticker;
+
+    us_ticker_clear_interrupt();
+
+    int_cnt++;
+}
+
+void timeout_callback()
+{
+    int_cnt++;
+}
+
+/* Verify if us ticker count ticks.
+ *
+ * Given is us ticker.
+ * When us ticker is initialised.
+ * Then us ticker counts ticks.
+ */
+void test_us_ticker_count_ticks(BMTest& test)
+{
+    us_ticker_init();
+
+    const unsigned int ticker_val_1 = us_ticker_read();
+
+    /* Wait 1000 cycles - this should be long enough to prove that ticker
+     * counter has been incremented. */
+    wait_cycles(1000);
+
+    const unsigned int ticker_val_2 = us_ticker_read();
+
+    BM_TEST_ASSERT(test, ticker_val_2 > ticker_val_1);
+}
+
+/* Verify if us ticker interrupt scheduling works.
+ *
+ * Given is us ticker.
+ * When us ticker is initialised and interrupt is set.
+ * Then us ticker interrupt handler is executed in the specified point in time.
+ */
+void test_us_ticker_schedule_int(BMTest& test)
+{
+    unsigned int timeout_values[] =
+    { 100, 200, 300 };
+
+    ticker_irq_handler_type org_us_ticker_irq_handler = set_us_ticker_irq_handler(us_ticker_isr);
+
+    for (unsigned int i = 0; i < (sizeof(timeout_values) / sizeof(unsigned int)); i++) {
+
+        us_ticker_init();
+
+        int_cnt = 0;
+
+        const unsigned int ticker_val_1 = us_ticker_read();
+
+        us_ticker_set_interrupt(ticker_val_1 + timeout_values[i]);
+
+        while (us_ticker_read() < (ticker_val_1 + timeout_values[i] - TICKS_DELTA)) {
+            BM_TEST_ASSERT(test, int_cnt == 0);
+        }
+
+        while (us_ticker_read() < (ticker_val_1 + timeout_values[i] + TICKS_DELTA)) {
+            /* just wait */
+        }
+
+        BM_TEST_ASSERT(test, int_cnt == 1);
+    }
+
+    set_us_ticker_irq_handler(org_us_ticker_irq_handler);
+}
+
+/* Verify if us ticker interrupt re-scheduling works.
+ *
+ * Given is us ticker.
+ * When us ticker is initialised and interrupt is set and then interrupt time is modified.
+ * Then us ticker interrupt handler is executed in the specified point in time.
+ */
+void test_us_ticker_reschedule_int(BMTest& test)
+{
+    ticker_irq_handler_type org_us_ticker_irq_handler = set_us_ticker_irq_handler(us_ticker_isr);
+
+    us_ticker_init();
+
+    int_cnt = 0;
+
+    const unsigned int ticker_val_1 = us_ticker_read();
+
+    us_ticker_set_interrupt(ticker_val_1 + 300);
+
+    wait_cycles(10);
+
+    us_ticker_set_interrupt(ticker_val_1 + 600);
+
+    while (us_ticker_read() < (ticker_val_1 + 600 - TICKS_DELTA)) {
+        BM_TEST_ASSERT(test, int_cnt == 0);
+    }
+
+    while (us_ticker_read() < (ticker_val_1 + 600 + TICKS_DELTA)) {
+        /* just wait */
+    }
+
+    BM_TEST_ASSERT(test, int_cnt == 1);
+
+    set_us_ticker_irq_handler(org_us_ticker_irq_handler);
+}
+
+/* Verify if us ticker configuration is valid.
+ *
+ * Given is us ticker.
+ * When us ticker configuration is provided.
+ * Then us ticker information indicate that frequency between 250KHz and 8MHz and the counter is at least 16 bits wide.
+ */
+void test_us_ticker_config(BMTest& test)
+{
+    const ticker_info_t* p_ticker_info = us_ticker_get_info();
+
+    BM_TEST_ASSERT(test, p_ticker_info->frequency >= 250000 && p_ticker_info->frequency <= 8000000);
+    BM_TEST_ASSERT(test, p_ticker_info->bits >= 16);
+}
+
+/* Verify if us ticker frequency is consistent with defined frequency.
+ *
+ * Given is us ticker.
+ * When us ticker is initialized.
+ * Then us ticker counter is incremented with the specified frequency.
+ */
+void test_us_ticker_freq(BMTest& test)
+{
+    const ticker_info_t* p_ticker_info = us_ticker_get_info();
+    char buffer[10];
+
+    test.receive(buffer);
+
+    const unsigned int ticker_val_1 = us_ticker_read();
+
+    test.receive(buffer);
+
+    const unsigned int ticker_val_2 = us_ticker_read();
+
+    BM_TEST_ASSERT(test, (ticker_val_2 - ticker_val_1) >= p_ticker_info->frequency - (p_ticker_info->frequency / 10));
+    BM_TEST_ASSERT(test, (ticker_val_2 - ticker_val_1) <= p_ticker_info->frequency + (p_ticker_info->frequency / 10));
+}
+
+/* Functional test of Timeout class.
+ *
+ * Given is Timeout class object.
+ * When us ticker is enabled and callback function is attached.
+ * Then attached function is called in the specified point in time.
+ */
+void test_timeout(BMTest& test)
+{
+    Timeout timeout;
+
+    int_cnt = 0;
+
+    timeout.attach(&timeout_callback, 0.3);
+
+    wait(0.1);
+
+    BM_TEST_ASSERT(test, int_cnt == 0);
+
+    wait(0.1);
+
+    BM_TEST_ASSERT(test, int_cnt == 0);
+
+    wait(0.11); // wait a little longer
+
+    BM_TEST_ASSERT(test, int_cnt == 1);
+
+    timeout.detach();
+
+    wait(0.5);
+
+    BM_TEST_ASSERT(test, int_cnt == 1);
+}
+
+int main()
+{
+    BMTest test;
+
+    test.set_transmission_params(USBTX, USBRX, BAUD_RATE);
+
+    test.sync_host_dev();
+
+    test.set_timeout(10);
+
+    test.exec_test_case(test_us_ticker_count_ticks, "Verify if us ticker counts ticks.", NULL);
+    test.exec_test_case(test_us_ticker_schedule_int, "Verify if us ticker interrupt scheduling works.", NULL);
+    test.exec_test_case(test_us_ticker_reschedule_int, "Verify if us ticker interrupt rescheduling works.", NULL);
+    test.exec_test_case(test_us_ticker_config, "Verify if us ticker configuration is valid.", NULL);
+    test.exec_test_case(test_us_ticker_freq, "Verify if us ticker frequency is valid.", "freq_test");
+    test.exec_test_case(test_timeout, "Functional test of Timeout class.", NULL);
+
+    test.done();
+
+    while (true)
+        ;
+}
+

--- a/low_level_tests/us_ticker/test.py
+++ b/low_level_tests/us_ticker/test.py
@@ -1,0 +1,334 @@
+"""
+mbed SDK
+Copyright (c) 2017 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import time
+import serial
+import sys
+import mbed_lstools
+from subprocess import Popen, PIPE, STDOUT
+import argparse
+import json
+import os
+import logging
+import atexit
+import threading
+
+"""! US TICKER TEST FOR GREEN TEA
+
+  TEST SCENARIO
+  This part of the test is executed on the host (PC).
+  
+  Actions performed by the script:
+  - build mbed part of the US TICKER test,
+  - request user to flash and reset the mbed board,
+  - perform us ticker test,
+  - report test status.
+  
+  For basic functionality of the Grean-Tea and utest frameworks us ticker is not
+  required. Advanced usage (using of asynchronous test cases) requires
+  running us ticker since utest framework uses Timeout class to execute call-backs
+  after the specified time.  
+  
+  Test cases:
+  - verify if us ticker counts ticks.
+  - verify if us ticker interrupt scheduling works.
+  - verify if us ticker interrupt re-scheduling works.
+  - verify if us ticker frequency and counter width is valid (consistent with the new standards)
+  - verify if us ticker frequency is consistent with declared frequency.
+  - verify if attached call-back to Timeout object is called in the specified point in time.
+  
+  Note:
+  This test verified enough of us ticker to enable greentea/utest.
+  This is not a full unit/integration tests for us ticker.
+  
+  Example usage:
+      test.py -m K64F -t GCC_ARM
+  This command will run test on K64F platform using GCC_ARM toolchain.
+  
+  For more options type:
+      test.py -h
+"""
+
+RETRY_LIMIT = 10
+
+SYNC_OK = 0
+SYNC_ERR = -1
+
+def serial_cleanup(serial_port):
+    """! Serial port clean-up handler.
+         This function closes opened serial port.
+         
+    @param serial_port serial port.
+    """
+    if (serial_port != None and serial_port.isOpen() == True):
+        serial_port.close()
+
+def build_test(target, toolchain, clean_flag):
+    """Build the mbed test.
+    
+    @param target target id.
+    @param toolchain compile toolchain.
+    @return image path.
+    """
+    logging.info('Building mbed UART test for green tea.')
+    
+    clean = ''
+    if (clean_flag):
+        clean = '-c'
+    
+    cmd = 'mbed compile -t %s -m %s --source . --source ../.. ' \
+          '--build-data build.log %s' \
+          % (toolchain, target, clean)
+    
+    image_path = str()
+    
+    # Remove build log file if exists
+    try:
+        os.remove('build.log')
+    except OSError:
+        pass
+    
+    try:
+        p = Popen(cmd, stdout=sys.stdout)
+    except OSError:
+        logging.exception ('Command cannot be executed.')
+        sys.exit()
+
+    # Check process status.
+    returncode = p.wait()
+    if returncode != 0:
+        logging.error('Error while executing command.')
+        sys.exit()
+    
+    # Get image path   
+    try:
+        with open('build.log') as f:
+            build_data = json.load(f)
+            image_path = build_data['builds'][0]['bin']
+    # Image path can not be found.
+    except (KeyError, IndexError, IOError, AttributeError): 
+        # If we are here, then build process has failed.
+        logging.exception ('Unable to locate image file.')
+        sys.exit()
+       
+    return image_path
+
+def serial_write_line(serial_port, line):
+    """Write line to the serial port.
+    
+    @param line line to be written.
+    """
+    serial_port.write(line+'\0')
+    logging.debug('[SEND] %s' % line)
+
+def serial_read_line(serial_port):
+    """Read line from the serial port with timeout.
+    
+    @return string read from the serial port.
+    """
+    limit = 0
+    line = str()
+    while (True):
+        if (serial_port.in_waiting == 0):
+            time.sleep(0.001)
+            limit += 1
+            if (limit == RETRY_LIMIT):
+                break
+        else:
+            limit = 0
+            c = serial_port.read()
+            if (c == '\0' or c == '\n'):
+                break
+            line += c
+    logging.debug('[RECV] -%s-' % line)
+    return line
+
+def sync_host_dev(serial_port):
+    """Synchronize host part with mbed part of the test.
+    
+    @param serial_port serial port.
+    """
+    for i in range(0, RETRY_LIMIT):
+        serial_write_line(serial_port, '__sync')
+        time.sleep(0.1)
+        resp = serial_read_line(serial_port)
+        if (resp == '__ready'):
+            return SYNC_OK
+    
+    return SYNC_ERR
+
+def test_commander(serial_port, test_support_functions):
+    """Function handles test execution. Decode command from mbed part of the test
+       and perform specific action. Command is encoded in JSON format. 
+    
+    @param serial_port serial port.
+    @param test_support_functions dictionary with test case support functions.
+    """
+    timeout_time = -1
+    
+    while (True):
+
+        line = serial_read_line(serial_port)
+
+        if (timeout_time > 0 and int(time.time()) > timeout_time):
+            logging.info('TEST TIMEOUT')
+            sys.exit()
+
+        # Assume that we received command (if reception timeout occurs, then we get empty string)
+        try:
+            # remove null terminator
+            cmd = json.loads(line)
+        except (ValueError):
+            # If this is not a command in JSON format, then print it out
+            if (line != ''):
+                logging.info(line)
+            continue
+            
+        if (cmd['cmd'] == 'timeout'):
+            timeout_time = int(time.time() + 1) + int(cmd['val'])
+            logging.info('Timeout: %s sec.\n' % cmd['val'])
+            
+        if (cmd['cmd'] == 'description'):
+            logging.info('--- Test case ---')
+            logging.info('Description: %s' % cmd['val'])
+                
+        if (cmd['cmd'] == 'host_test' and cmd['val'] != '(null)'):
+            test_support_functions[cmd['val']](serial_port)
+
+        if (cmd['cmd'] == 'assert'):
+            logging.info(cmd['val'])
+
+        if (cmd['cmd'] == 'status'):
+            if(cmd['val'] == "PASSED"):
+                logging.info('Result: PASSED\n')
+            else:
+                logging.info('Result: FAILED\n')
+            
+        if (cmd['cmd'] == 'done'):
+            logging.info('--- Test execution status ---\nTOTAL EXECUTED TEST CASES: %s\nPASSED: %s\nFAILED: %s\n', 
+                         cmd['val']['total'], cmd['val']['passed'], cmd['val']['failed'])
+                
+            if (int(cmd['val']['failed']) == 0 and int(cmd['val']['total']) == int(cmd['val']['passed'])):
+                logging.info('All test cases executed successfully!')
+                logging.info('TEST PASSED')
+            else:
+                logging.info('TEST FAILED')
+            break
+
+def support_freq_test(serial_port):
+    """Support function for frequency test.
+    
+    @param serial_port serial port.
+    """
+    
+    time.sleep(0.1)
+    
+    serial_write_line(serial_port, 'start')
+    time.sleep(1)
+    serial_write_line(serial_port, 'stop_')
+
+def main():
+    serial_port = None
+    sel_platform_id = None
+    muts_list = None
+    
+    test_support_functions = {
+        "freq_test": support_freq_test,
+    }
+
+    # Prepare required/optional arguments.
+    parser = argparse.ArgumentParser(description='Execute US ticker bare metal test to check if platform is ready to use green tea.')
+    parser.add_argument("-m", "--target", help="Target id", required=True)
+    parser.add_argument("-t", "--toolchain", help="Compile toolchain. Example: ARM, GCC_ARM, IAR.", default='GCC_ARM')
+    parser.add_argument("-c", "--clean", action='store_true', help="Perform a clean build.")
+    parser.add_argument("-v", "--verbose", action='store_true', help="Increase output verbosity.", default=0)
+    args = parser.parse_args()
+    
+    # Set verbosity level (print transmission details or not)
+    if (args.verbose):
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
+
+    # Create list of connected mbed devices.
+    mbeds = mbed_lstools.create()
+    muts_list = mbeds.list_mbeds()
+
+    # Print platform and baud rate info.
+    logging.info('Selected platform: %s.' % (args.target))
+
+    # Print list of devices with details.
+    logging.info('Available platforms: ')
+    for i, mut in enumerate(muts_list):
+        sel_str = ''
+        if (mut['platform_name'] == args.target):
+            sel_platform_id = i
+            sel_str = '  --- SELECTED ---'
+        logging.info('%-20s %-10s %-10s %-10s' % (mut['platform_name'], mut['serial_port'], mut['mount_point'], sel_str))
+
+    # If our device is not on the list of connected mbed devices, then quit.
+    if (sel_platform_id == None):
+        logging.info('Provided platform - %s has not been found.' % (args.target))
+        sys.exit()
+
+    # Build the test.
+    build_test(args.target, args.toolchain, args.clean)
+
+    # Inform what to do next.
+    logging.info('Perform the following steps: \n'
+                 '1. Copy the binary file to the board.\n'
+                 '2. Press the reset button on the mbed board to start the program.\n'
+                 '3. Press Enter to start the test...\n')
+
+    # Wait for signal to continue.
+    raw_input('')
+
+    # Indicate start of the communication test.
+    logging.info('Starting test, please wait...')
+    
+    # Open serial port.
+    try:
+        serial_port = serial.Serial(port = muts_list[sel_platform_id]['serial_port'],
+                                    baudrate = 9600,
+                                    parity = serial.PARITY_NONE,
+                                    stopbits = serial.STOPBITS_ONE,
+                                    bytesize = serial.EIGHTBITS)
+
+        # Register clean-up exit handler
+        atexit.register(serial_cleanup, serial_port)
+    
+    except (ValueError, serial.SerialException):
+        logging.exception ('Could not open serial port.')
+        sys.exit()
+        
+    
+    # Sync both parts of the test
+    if(sync_host_dev(serial_port) == SYNC_ERR):
+        logging.error('Host - Device synchronisation error.')
+        sys.exit()
+    
+    logging.info('Host - Device synchronisation complete.')
+    
+    logging.info('Starting test.')
+    
+    # Start the test
+    test_commander(serial_port, test_support_functions)
+    
+    sys.exit()
+
+if  __name__ =='__main__':
+    main()
+    


### PR DESCRIPTION
## Description

This is a proposition of us ticker low level test for Green Tea.

This is continuation of: PR https://github.com/ARMmbed/mbed-os/pull/5744.

Requirements:

> When vendors start porting a platform to mbed OS, they need to take big steps before they actually can start running tests. One of the first requirements to run greentea is functional us ticker, unfortunately there's nothing that would tell whether the implementation is correct. This can assume working UART as proved in https://jira.arm.com/browse/IOTMORF-1244
> Analyse greentea to identify us ticker usecases that need to be tested to ensure the greentea will work correctly.
> Create tests set:
> it shouldn't use greentea
> can be run on minimal (not complete) mbed OS port
> doesn't use other part of the system except UART (to the extent validated in IOTMORF-1244)
> tests enough of us ticker to enable greentea
> doesnt need to be full unit/integration tests for us ticker

Files:
test.py - host part of the test. This script builds mbed part of the test and performs us ticker test.
main.cpp - source file for mbed part of the test to verify if us ticker driver is correctly implemented.

lib/BMComm.h - class which provides communication between host and device.
lib/BMTest.h - class which provides support for bare metal tests.

Example usage:
- copy `low_level_tests` directory into the `mbed-os` root directory.
- enter `mbed-os/low_level_tests/uart` directory,
- execute the following command: `python test.py -t GCC_ARM -m NUCLEO_F070RB` - run test using GCC_ARM toolchain and NUCLEO_F070RB board,
- `python test.py -h` - see detail usage information.

## Status

HOLD

## Migrations
NO